### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-I2CGPS KEYWORD1
+I2CGPS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-check 			KEYWORD2
-available 		KEYWORD2
-read 			KEYWORD2
-sendMTKpacket 	KEYWORD2
+begin	KEYWORD2
+check	KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+sendMTKpacket	KEYWORD2
 createMTKpacket	KEYWORD2
 calcCRCforMTK	KEYWORD2
 createPGCMDpacket	KEYWORD2
 sendPGCMDpacket	KEYWORD2
 
-enableDebugging KEYWORD2
-disableDebugging KEYWORD2
+enableDebugging	KEYWORD2
+disableDebugging	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords