### PR TITLE
A hybridized Arduino and mBed-OS version of the library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Repository Contents
 * **/src** - Source files for the library (.cpp, .h). These are hybridized versions that work under Arduino and mBed as well.
 * **keywords.txt** - Keywords from this library that will be highlighted in the Arduino IDE. 
 * **library.properties** - General library properties for the Arduino package manager.
-* **main.cpp** Basic example code for mBed-OS.
-* **externs.h** Needed by mBed-OS to let .h and .cpp files use the same I2C and Serial definition.
+* **main.cpp** - Basic example code for mBed-OS.
+* **externs.h** - Needed by mBed-OS to let .h and .cpp files use the same I2C and Serial definition.
 
 Documentation
 --------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ SparkFun MediaTek I2C Interface Library
 
 The Qwiic GPS uses the Titan X1 GPS module with special I2C firmware. This library talks to the GPS module over I2C.
 
-We recommend using the [TinyGPS++ library](https://github.com/mikalhart/TinyGPSPlus) in addition to this library. Works like a champ together.
+For Arduino we recommend using the [TinyGPS++ library](https://github.com/mikalhart/TinyGPSPlus) in addition to this library. Works like a champ together.
+
+For mBed-OS use [codygrays port of the TinyGPS++ library](https://github.com/codygray/TinyGPSPlus/tree/universal) instead.
 
 Library written by Nathan Seidle ([SparkFun](http://www.sparkfun.com)).
 
@@ -15,9 +17,11 @@ Repository Contents
 -------------------
 
 * **/examples** - Example sketches for the library (.ino). Run these from the Arduino IDE. 
-* **/src** - Source files for the library (.cpp, .h).
+* **/src** - Source files for the library (.cpp, .h). These are hybridized versions that work under Arduino and mBed as well.
 * **keywords.txt** - Keywords from this library that will be highlighted in the Arduino IDE. 
-* **library.properties** - General library properties for the Arduino package manager. 
+* **library.properties** - General library properties for the Arduino package manager.
+* **main.cpp** Basic example code for mBed-OS.
+* **externs.h** Needed by mBed-OS to let .h and .cpp files use the same I2C and Serial definition.
 
 Documentation
 --------------

--- a/externs.h
+++ b/externs.h
@@ -1,0 +1,5 @@
+#ifndef EXTERNS_H
+#define EXTERNS_H
+extern I2C i2c;
+extern Serial pc;
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,84 @@
+#include "mbed.h"
+#include "lib/SparkFun_I2C_GPS_Reading_and_Control/SparkFun_I2C_GPS_Arduino_Library.h"
+#include "externs.h"
+
+I2C i2c(I2C1_SDA, I2C1_SCL);
+Serial pc(USBTX, USBRX, 115200);
+I2CGPS myI2CGPS;
+TinyGPSPlus gps;
+string configString;
+
+//Display new GPS info
+void displayInfo()
+{
+  //We have new GPS data to deal with!
+  pc.printf("\n");
+
+  // display date time
+  if (gps.time.isValid())
+  {
+    pc.printf("Datum: %d/%02d/%02d  --  %02d:%02d:%02d\n",
+                         gps.date.year(), gps.date.month(), gps.date.day(),
+                         gps.time.hour(), gps.time.minute(), gps.time.second());
+  }
+  else
+  {
+    pc.printf("Time not yet valid\n");
+  }
+
+  // display location
+  if (gps.location.isValid())
+  {
+    pc.printf("Location: %f, %f\n", gps.location.lat(), gps.location.lng());
+  }
+  else
+  {
+    pc.printf("Location not yet valid\n");
+  }
+
+  // display altitude
+  if (gps.altitude.isValid())
+  {
+    pc.printf("Altitude in meters: %f in feet: %f\n", gps.altitude.meters(), gps.altitude.feet());
+  }
+
+  // display satellite stats
+  if (gps.satellites.isValid())
+  {
+    pc.printf(" Satellites in View: %d", gps.satellites.value());
+  }
+
+  // display HDOP
+  if (gps.hdop.isValid())
+  {
+    pc.printf(" HDOP: %.2f\n", (gps.hdop.value()/100.0));
+  }
+}
+
+
+// main() runs in its own thread in the OS
+int main() {
+
+  while (myI2CGPS.begin(i2c, 400000) == false) {
+    pc.printf("Module failed to respond. Please check wiring.\n");
+    ThisThread::sleep_for(500);
+  }
+  pc.printf("GPS module found!\n");
+
+  /* if GPS module is found let us configure it */
+  // setup PPS LED
+  configString = myI2CGPS.createMTKpacket(285, ",4,25");
+  myI2CGPS.sendMTKpacket(configString);
+
+
+  while (true) {
+    while (myI2CGPS.available()) // available() returns the number of new bytes
+                                 // available from the GPS module
+    {
+      uint8_t incoming = myI2CGPS.read(); //Read the latest byte from Qwiic GPS
+      if(incoming == '$') pc.printf("\n"); //Break the sentences onto new lines
+      pc.printf("%c", incoming); //Print this character
+    }
+  }
+  return 0;
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,5 @@
 #include "mbed.h"
-#include "lib/SparkFun_I2C_GPS_Reading_and_Control/SparkFun_I2C_GPS_Arduino_Library.h"
+#include "src/SparkFun_I2C_GPS_Reading_and_Control/SparkFun_I2C_GPS_Arduino_Library.h"
 #include "externs.h"
 
 I2C i2c(I2C1_SDA, I2C1_SCL);

--- a/main.cpp
+++ b/main.cpp
@@ -5,55 +5,7 @@
 I2C i2c(I2C1_SDA, I2C1_SCL);
 Serial pc(USBTX, USBRX, 115200);
 I2CGPS myI2CGPS;
-TinyGPSPlus gps;
 string configString;
-
-//Display new GPS info
-void displayInfo()
-{
-  //We have new GPS data to deal with!
-  pc.printf("\n");
-
-  // display date time
-  if (gps.time.isValid())
-  {
-    pc.printf("Datum: %d/%02d/%02d  --  %02d:%02d:%02d\n",
-                         gps.date.year(), gps.date.month(), gps.date.day(),
-                         gps.time.hour(), gps.time.minute(), gps.time.second());
-  }
-  else
-  {
-    pc.printf("Time not yet valid\n");
-  }
-
-  // display location
-  if (gps.location.isValid())
-  {
-    pc.printf("Location: %f, %f\n", gps.location.lat(), gps.location.lng());
-  }
-  else
-  {
-    pc.printf("Location not yet valid\n");
-  }
-
-  // display altitude
-  if (gps.altitude.isValid())
-  {
-    pc.printf("Altitude in meters: %f in feet: %f\n", gps.altitude.meters(), gps.altitude.feet());
-  }
-
-  // display satellite stats
-  if (gps.satellites.isValid())
-  {
-    pc.printf(" Satellites in View: %d", gps.satellites.value());
-  }
-
-  // display HDOP
-  if (gps.hdop.isValid())
-  {
-    pc.printf(" HDOP: %.2f\n", (gps.hdop.value()/100.0));
-  }
-}
 
 
 // main() runs in its own thread in the OS

--- a/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -31,7 +31,6 @@
 #include <iostream>
 #include <stdlib.h>
 char dummy = 0;
-char buffer[255];
 #endif
 
 //Sets up the sensor for constant read

--- a/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -117,7 +117,7 @@ void I2CGPS::check()
   for (uint8_t x = 0; x < MAX_PACKET_SIZE; x++)
   {
         buffer[0]='\0';
-        int err_read = _i2cPort->read(MT333x_ADDR << 1|1, (char *)& buffer[x], 1);
+        _i2cPort->read(MT333x_ADDR << 1|1, (char *)& buffer[x], 1);
 
     if (buffer[x] != 0x0A)
     {
@@ -237,7 +237,7 @@ bool I2CGPS::sendMTKpacket(string command)
 
     return (false);
   }
-  _debugSerial->printf("command: %s   length: %d\n", command.c_str(), command.length());
+ 
   _i2cPort->write(MT333x_ADDR << 1, command.c_str(), command.length());
   ThisThread::sleep_for(10);
 
@@ -269,7 +269,6 @@ string I2CGPS::createMTKpacket(uint16_t packetType, string dataField)
   if (packetType < 10)
     configSentence += "0";
   configSentence += to_string(packetType);
-  //_debugSerial->printf("packet type: %d    c sentence: %s\n", packetType, configSentence.c_str());
 
   //Attach any settings
   if (dataField.length() > 0)


### PR DESCRIPTION
Modified the library to work under mBed-OS as well.
Magic is done via preprocessor definitions, this way we do not need separate library files for each framework. 

As mBed-OS works somewhat different than Arduino, it also needs the externs.h file found in root. This file enables usage the same I2C and Serial definition in all the .h and .cpp files.

main.cpp contains a basic mBed-OS example that will output raw NMEA sentences. Would you need to parse those, you will need to incorporate [codygray's port of the TinyGPS++ library](https://github.com/codygray/TinyGPSPlus/tree/universal)



This port has been tested on MAX32630FTHR and mBed v5.14.2