### PR TITLE
Update SparkFun_I2C_GPS_Arduino_Library.cpp

### DIFF
--- a/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -251,7 +251,11 @@ string I2CGPS::createMTKpacket(uint16_t packetType, string dataField)
     configSentence += "0";
   if (packetType < 10)
     configSentence += "0";
+#if defined (ARDUINO)
+  configSentence += String(packetType);
+#elif defined (__MBED__)
   configSentence += to_string(packetType);
+#endif
 
   //Attach any settings
   if (dataField.length() > 0)
@@ -335,7 +339,11 @@ string I2CGPS::createPGCMDpacket(uint16_t packetType, string dataField)
     configSentence += "0";
   if (packetType < 10)
     configSentence += "0";
+#if defined (ARDUINO)
+  configSentence += String(packetType);
+#elif defined (__MBED__)
   configSentence += to_string(packetType);
+#endif
 
   //Attach any settings
   if (dataField.length() > 0)


### PR DESCRIPTION
The function `to_string()` seems exclusive to `MBED`. [Users](https://forum.sparkfun.com/viewtopic.php?f=105&t=53086) will get this error.

    Arduino: 1.8.12 (Windows 10), Board: "Arduino Uno"
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp: In member function 'String I2CGPS::createMTKpacket(uint16_t, String)':
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp:254:21: error: 'to_string' was not declared in this scope
    
       configSentence += to_string(packetType);
    
                         ^~~~~~~~~
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp:254:21: note: suggested alternative: 'String'
    
       configSentence += to_string(packetType);
    
                         ^~~~~~~~~
    
                         String
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp: In member function 'String I2CGPS::createPGCMDpacket(uint16_t, String)':
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp:338:21: error: 'to_string' was not declared in this scope
    
       configSentence += to_string(packetType);
    
                         ^~~~~~~~~
    
    C:\Users\user_bob\Documents\Arduino\libraries\SparkFun_I2C_GPS_Reading_and_Control\src\SparkFun_I2C_GPS_Arduino_Library.cpp:338:21: note: suggested alternative: 'String'
    
       configSentence += to_string(packetType);
    
                         ^~~~~~~~~

                         String

Adding a preprocessor define to wrap it with the `String()` function when using it with `Arduino` so that it can compile. 