### PR TITLE
Added support for Particle devices

### DIFF
--- a/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -35,7 +35,7 @@ char dummy = 0;
 
 //Sets up the sensor for constant read
 //Returns false if sensor does not respond
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 boolean I2CGPS::begin(TwoWire &wirePort, uint32_t i2cSpeed)
 {
   //Bring in the user's choices
@@ -89,7 +89,7 @@ void I2CGPS::check()
 
   for (uint8_t x = 0; x < MAX_PACKET_SIZE; x++)
   {
-    #if defined (ARDUINO)
+    #if defined (ARDUINO) || defined(PARTICLE)
     if (x % 32 == 0)                          //Arduino can only Wire.read() in 32 byte chunks. Yay.
       _i2cPort->requestFrom(MT333x_ADDR, 32); //Request 32 more bytes
 
@@ -106,7 +106,7 @@ void I2CGPS::check()
       _head %= MAX_PACKET_SIZE; //Wrap variable
 
       if (_printDebug == true && _head == _tail)
-        #if defined (ARDUINO)
+        #if defined (ARDUINO) || defined(PARTICLE)
         _debugSerial->println(F("Buffer overrun"));
         #elif defined (__MBED__)
         _debugSerial->printf("Buffer overrun\n");
@@ -168,7 +168,7 @@ void I2CGPS::disableDebugging()
 //Send a given command or configuration string to the module
 //The input buffer on the MTK is 255 bytes. Caller must keep strings shorter than 255 bytes
 //Any time you end transmission you must give the module 10ms to process bytes
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 boolean I2CGPS::sendMTKpacket(String command)
 {
   if (command.length() > 255)
@@ -232,7 +232,7 @@ bool I2CGPS::sendMTKpacket(string command)
 //config sentence complete with CRC and \r \n ending bytes
 //PMTK uses a different packet numbers to do configure the module.
 //These vary from 0 to 999. See 'MTK NMEA Packet' datasheet for more info.
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 String I2CGPS::createMTKpacket(uint16_t packetType, String dataField)
 {
   //Build config sentence using packetType
@@ -251,7 +251,7 @@ string I2CGPS::createMTKpacket(uint16_t packetType, string dataField)
     configSentence += "0";
   if (packetType < 10)
     configSentence += "0";
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
   configSentence += String(packetType);
 #elif defined (__MBED__)
   configSentence += to_string(packetType);
@@ -276,7 +276,7 @@ string I2CGPS::createMTKpacket(uint16_t packetType, string dataField)
 
 //Calculate CRC for MTK messages
 //Given a string of characters, XOR them all together and return CRC in string form
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 String I2CGPS::calcCRCforMTK(String sentence)
 {
 #elif defined (__MBED__)
@@ -290,7 +290,7 @@ string I2CGPS::calcCRCforMTK(string sentence)
   for (uint8_t x = 1; x < sentence.length() - 1; x++)
     crc ^= sentence[x]; //XOR this byte with all the others
 
-  #if defined (ARDUINO)
+  #if defined (ARDUINO) || defined(PARTICLE)
   String output = "";
   #elif defined (__MBED__)
   string output = "";
@@ -298,7 +298,7 @@ string I2CGPS::calcCRCforMTK(string sentence)
   if (crc < 10)
     output += "0"; //Append leading zero if needed
 
-  #if defined (ARDUINO)
+  #if defined (ARDUINO) || defined(PARTICLE)
   output += String(crc, HEX);
   #elif defined (__MBED__)
   static char outhex[4];
@@ -310,7 +310,7 @@ string I2CGPS::calcCRCforMTK(string sentence)
   return (output);
 }
 
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 boolean I2CGPS::sendPGCMDpacket(String command)
 {
 #elif defined (__MBED__)
@@ -320,7 +320,7 @@ bool I2CGPS::sendPGCMDpacket(string command)
   return (sendMTKpacket(command)); // Send process is the same, re-named to ease user's minds
 }
 
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
 String I2CGPS::createPGCMDpacket(uint16_t packetType, String dataField)
 {
   //Build config sentence using packetType
@@ -339,7 +339,7 @@ string I2CGPS::createPGCMDpacket(uint16_t packetType, string dataField)
     configSentence += "0";
   if (packetType < 10)
     configSentence += "0";
-#if defined (ARDUINO)
+#if defined (ARDUINO) || defined(PARTICLE)
   configSentence += String(packetType);
 #elif defined (__MBED__)
   configSentence += to_string(packetType);

--- a/src/SparkFun_I2C_GPS_Arduino_Library.h
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.h
@@ -39,6 +39,8 @@
 #include <cstdlib>
 #include <string>
 #include "TinyGPSPlus/TinyGPS++.h"
+#elif defined(PARTICLE)
+#include"Particle.h"
 #endif
 
 
@@ -56,7 +58,7 @@ class I2CGPS {
   public:
 
     //By default use Wire, standard I2C speed, and the default AK9750 address
-    #if defined(ARDUINO)
+    #if defined(ARDUINO) || defined(PARTICLE)
     boolean begin(TwoWire &wirePort = Wire, uint32_t i2cSpeed = I2C_SPEED_STANDARD);
     #elif defined (__MBED__)
     bool begin(I2C &wirePort = i2c, uint32_t i2cSpeed = I2C_SPEED_STANDARD);
@@ -66,7 +68,7 @@ class I2CGPS {
     uint8_t available(); //Returns available number of bytes. Will call check() if zero is available.
     uint8_t read(); //Returns the next available byte
 
-    #if defined(ARDUINO)
+    #if defined(ARDUINO) || defined(PARTICLE)
     void enableDebugging(Stream &debugPort = Serial); //Output various extra messages to help with debug
     #elif defined (__MBED__)
     void enableDebugging(Stream &debugPort = pc);
@@ -74,7 +76,7 @@ class I2CGPS {
 
     void disableDebugging();
 
-    #if defined(ARDUINO)
+    #if defined(ARDUINO) || defined(PARTICLE)
     boolean sendMTKpacket(String command);
     String createMTKpacket(uint16_t packetType, String dataField);
     String calcCRCforMTK(String sentence); //XORs all bytes between $ and *
@@ -98,7 +100,7 @@ class I2CGPS {
   private:
 
     //Variables
-    #if defined(ARDUINO)
+    #if defined(ARDUINO) || defined(PARTICLE)
     TwoWire *_i2cPort; //The generic connection to user's chosen I2C hardware
     boolean _printDebug = false; //Flag to print the serial commands we are sending to the Serial port for debug
     #elif defined (__MBED__)


### PR DESCRIPTION
I've added support to Particle devices (argon, boron, photon) by checking if PARTICLE is defined and including the <Particle.h> library. The code was tested successfully using Sparkfun GPS Breakout XA1110.