### PR TITLE
Fix other i2c devices

### DIFF
--- a/src/SparkFun_I2C_GPS_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_GPS_Arduino_Library.cpp
@@ -53,6 +53,9 @@ boolean I2CGPS::begin(TwoWire &wirePort, uint32_t i2cSpeed)
   _i2cPort->endTransmission();
 
   if (_i2cPort->requestFrom(MT333x_ADDR, 1))
+    while(_i2cPort->available()) {
+      _i2cPort->read();
+    }
     return (true); //Success!
   else
     return (false); //Module failed to respond


### PR DESCRIPTION
I have found that unless I flush the i2c buffer after requestFrom() in begin(), messages from other i2c devices are random values. This fixes the issue, but I am not sure why, my guess is this message is left in the buffer and from then on, all messages from other devices are off by 1 byte?